### PR TITLE
Bump watchdog and base rust version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+build

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:1.27.1
+FROM rust:1.34-slim as build
 
 RUN apt-get update -qy \
     && apt-get install -qy curl ca-certificates --no-install-recommends \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.7.1/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apt-get -qy remove curl \
     && apt-get clean \
@@ -16,9 +16,9 @@ COPY main ./main
 
 RUN cargo install --path ./main
 
-HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
+HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 
-ENV fprocess=main
+ENV fprocess="main"
 
 CMD ["fwatchdog"]
 

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -1,13 +1,12 @@
-FROM rust:1.34-slim as build
+FROM openfaas/classic-watchdog:0.18.0 as watchdog
+
+FROM rust:1.37-slim-stretch as build
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 RUN apt-get update -qy \
-    && apt-get install -qy curl ca-certificates --no-install-recommends \ 
-    && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && apt-get -qy remove curl \
-    && apt-get clean \
-&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -qy curl ca-certificates
 
 WORKDIR /usr/src/openfaas
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

* Moves rust up to 1.34 
* Moves watchdog up to 0.13.0 which support httpProbe health-checks
