### PR TITLE
Use alpine as builder and runner

### DIFF
--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -1,23 +1,35 @@
 FROM openfaas/classic-watchdog:0.18.0 as watchdog
 
-FROM rust:1.37-slim-stretch as build
+# Build Stage
+FROM rust:1.37.0-alpine AS builder
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+RUN USER=root
+WORKDIR /usr/src/openfaas
+COPY function ./function
+COPY main ./main
+
+RUN cd main && cargo build --release
+
+RUN cd main && cargo install --target x86_64-unknown-linux-musl --path .
+
+# Runner stage
+FROM alpine:3.12 as runner 
+
+RUN apk --no-cache add curl ca-certificates \
+    && addgroup -S app && adduser -S -g app app
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
-RUN apt-get update -qy \
-    && apt-get install -qy curl ca-certificates
-
-WORKDIR /usr/src/openfaas
-
-COPY function ./function
-COPY main ./main
-
-RUN cargo install --path ./main
+COPY --from=builder /usr/local/cargo/bin/main /usr/bin/main
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 
 ENV fprocess="main"
+
+RUN ls -la /
 
 CMD ["fwatchdog"]
 


### PR DESCRIPTION
First I would like to thank for sharing this example

I was cheeky enough to change the builder and runner to be alpine. It was like 1gb the image before, now it is only 23mb.
